### PR TITLE
Fix BASE_DIR; use it in tests.

### DIFF
--- a/mapusaurus/censusdata/tests/test_loader.py
+++ b/mapusaurus/censusdata/tests/test_loader.py
@@ -5,10 +5,10 @@ import tempfile
 from django.test import TestCase
 from mock import patch
 
+import geo.errors
 from censusdata import models
 from censusdata.management.commands.load_summary_one import Command
-
-import geo.errors
+from mapusaurus.settings.settings import BASE_DIR
 
 class LoadSummaryDataTest(TestCase):
     fixtures = ['mock_geo']
@@ -25,8 +25,9 @@ class LoadSummaryDataTest(TestCase):
     def test_handle(self, hf3, hf4, hf5):
         # Create Mock GEO file
         year = '2013'
-        shutil.copyfile(os.path.join("censusdata", "tests", "mock_geo.txt"),
-                        os.path.join(self.tempdir, "ZZgeo2010.sf1"))
+        shutil.copyfile(
+            os.path.join(BASE_DIR, "censusdata", "tests", "mock_geo.txt"),
+            os.path.join(self.tempdir, "ZZgeo2010.sf1"))
 
         command = Command()
         command.handle(os.path.join(self.tempdir, 'ZZgeo2010.sf1'), year)
@@ -48,8 +49,9 @@ class LoadSummaryDataTest(TestCase):
         geo.errors.in_2010 = {'11001000100': '22002000200', '11001000902': None}
 
         # Create Mock GEO file
-        shutil.copyfile(os.path.join("censusdata", "tests", "mock_geo.txt"),
-                        os.path.join(self.tempdir, "ZZgeo2010.sf1"))
+        shutil.copyfile(
+            os.path.join(BASE_DIR, "censusdata", "tests", "mock_geo.txt"),
+            os.path.join(self.tempdir, "ZZgeo2010.sf1"))
 
         command = Command()
         command.handle(os.path.join(self.tempdir, 'ZZgeo2010.sf1'), year)
@@ -62,8 +64,9 @@ class LoadSummaryDataTest(TestCase):
         geo.errors.in_2010 = old_geo_errors
 
     def test_handle_filethree(self):
-        shutil.copyfile(os.path.join("censusdata", "tests", "mock_file3.txt"),
-                        os.path.join(self.tempdir, "ZZ000032010.sf1"))
+        shutil.copyfile(
+            os.path.join(BASE_DIR, "censusdata", "tests", "mock_file3.txt"),
+            os.path.join(self.tempdir, "ZZ000032010.sf1"))
         command = Command()
         command.handle_filethree(os.path.join(self.tempdir, "ZZgeo2010.sf1"),
                                  '2013', '11',  # State
@@ -88,8 +91,9 @@ class LoadSummaryDataTest(TestCase):
         self.assertEqual(len(models.Census2010RaceStats.objects.all()), 0)
 
     def test_handle_filethree_no_delete(self):
-        shutil.copyfile(os.path.join("censusdata", "tests", "mock_file3.txt"),
-                        os.path.join(self.tempdir, "ZZ000032010.sf1"))
+        shutil.copyfile(
+            os.path.join(BASE_DIR, "censusdata", "tests", "mock_file3.txt"),
+            os.path.join(self.tempdir, "ZZ000032010.sf1"))
         command = Command()
         command.handle_filethree(os.path.join(self.tempdir, "ZZgeo2010.sf1"),
                                  '2013', '11',  # State
@@ -108,8 +112,9 @@ class LoadSummaryDataTest(TestCase):
         models.Census2010RaceStats.objects.all().delete()
 
     def test_handle_filefive(self):
-        shutil.copyfile(os.path.join("censusdata", "tests", "mock_file5.txt"),
-                        os.path.join(self.tempdir, "ZZ000052010.sf1"))
+        shutil.copyfile(
+            os.path.join(BASE_DIR, "censusdata", "tests", "mock_file5.txt"),
+            os.path.join(self.tempdir, "ZZ000052010.sf1"))
         command = Command()
         command.handle_filefive(os.path.join(self.tempdir, "ZZgeo2010.sf1"),
                                 '2013', '11',  # State

--- a/mapusaurus/hmda/tests/test_loader.py
+++ b/mapusaurus/hmda/tests/test_loader.py
@@ -5,6 +5,7 @@ from mock import Mock, patch
 
 from hmda.management.commands.load_hmda import Command
 from hmda.models import HMDARecord
+from mapusaurus.settings.settings import BASE_DIR
  
 
 class LoadHmdaTest(TestCase):
@@ -13,7 +14,10 @@ class LoadHmdaTest(TestCase):
     def test_handle(self):
         command = Command()
         command.stdout = Mock()
-        command.handle(os.path.join("hmda", "tests", "mock_2013.csv"),2013)
+        command.handle(
+            os.path.join(BASE_DIR, "hmda", "tests", "mock_2013.csv"),
+            2013,
+        )
 
         # The mock data file contains 10 records, 8 for known states
         self.assertEqual(8, HMDARecord.objects.count())
@@ -36,7 +40,10 @@ class LoadHmdaTest(TestCase):
         errors.in_2010 = {'1122233300': '9988877766'}
         command = Command()
         command.stdout = Mock()
-        command.handle(os.path.join("hmda", "tests", "mock_2013.csv"), '2013')
+        command.handle(
+            os.path.join(BASE_DIR, "hmda", "tests", "mock_2013.csv"),
+            '2013',
+        )
 
         geos = set(r.geo_id for r in HMDARecord.objects.all())
         self.assertEqual(4, len(geos))
@@ -51,7 +58,8 @@ class LoadHmdaTest(TestCase):
         command = Command()
         command.stdout = Mock()
 
-        main_csv_directory = os.path.abspath( os.path.join("hmda", "tests") )
+        main_csv_directory = os.path.abspath(os.path.join(
+            BASE_DIR, "hmda", "tests"))
 
         main_csv_directory = main_csv_directory + "/"
 

--- a/mapusaurus/mapusaurus/settings/settings.py
+++ b/mapusaurus/mapusaurus/settings/settings.py
@@ -11,7 +11,7 @@ https://docs.djangoproject.com/en/1.6/ref/settings/
 # Build paths inside the project like this: os.path.join(BASE_DIR, ...)
 import os
 import sys
-BASE_DIR = os.path.dirname(os.path.dirname(__file__))
+BASE_DIR = os.path.dirname(os.path.dirname(os.path.dirname(__file__)))
 
 
 # Quick-start development settings - unsuitable for production
@@ -85,8 +85,6 @@ USE_I18N = True
 USE_L10N = True
 
 USE_TZ = True
-
-TEMPLATE_DIRS = [os.path.join(BASE_DIR, 'templates')]
 
 
 # Static files (CSS, JavaScript, Images)


### PR DESCRIPTION
Tests were failing when ran from the root of the project. This resolves by
consistently using the BASE_DIR when loading files in tests. This original
BASE_DIR was set up with the assumption it'd be one level shallower.