### PR TITLE
Add .docker dir to Docker image.

### DIFF
--- a/.docker/start_server.sh
+++ b/.docker/start_server.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-if [ ${DEBUG^^} == "TRUE" ]; then
+if [ "${DEBUG^^}" == "TRUE" ]; then
   python mapusaurus/manage.py runserver 0.0.0.0:"$PORT"
 else
   cd mapusaurus

--- a/Dockerfile
+++ b/Dockerfile
@@ -11,6 +11,7 @@ WORKDIR /app
 RUN pipenv install
 
 COPY ["mapusaurus", "/app/mapusaurus"]
+COPY [".docker", "/app/.docker"]
 RUN pipenv run python mapusaurus/manage.py collectstatic --noinput -c
 
 ENV ALLOWED_HOSTS="[\"localhost\", \"0.0.0.0\", \"127.0.0.1\"]"\


### PR DESCRIPTION
Oversight from #12; we need to have the .docker dir inside the container. This
also resolves an issue with the start_server.sh command.