### PR TITLE
Fix summary tables

### DIFF
--- a/censusdata/tests/test_views_utilities.py
+++ b/censusdata/tests/test_views_utilities.py
@@ -1,8 +1,6 @@
 """
 tests of the helper functions for assembling tables for map page
 """
-from decimal import Decimal
-
 from django.http import HttpRequest
 from django.test import TestCase
 
@@ -64,7 +62,7 @@ class ViewsUtilitiesTests(TestCase):
         """
         self.assertEqual(odds_ratio(1, 1), 1)
         self.assertEqual(odds_ratio(2, 5), 0)
-        self.assertEqual(odds_ratio(0.2, 0.3), Decimal('0.583'))
+        self.assertEqual(odds_ratio(0.2, 0.3), 0.583)
         self.assertEqual(odds_ratio(0.5, 0.5), 1)
         self.assertIsNone(odds_ratio(1, 0))
         self.assertIsNone(odds_ratio(0, 0))

--- a/censusdata/views.py
+++ b/censusdata/views.py
@@ -75,12 +75,12 @@ def assemble_stats(lma_sum, mma_sum, hma_sum, peer_lma_sum, peer_mma_sum, peer_h
             THREE_PLACES, rounding=ROUND_HALF_UP)
         stats.update({
                 'lma': lma_sum, 
-                'lma_pct': lma_pct, 
+                'lma_pct': float(lma_pct),
                 'mma': mma_sum,
-                'mma_pct': mma_pct,
+                'mma_pct': float(mma_pct),
                 'hma': hma_sum,
-                'hma_pct': hma_pct,
-                'maj_pct': maj_pct,
+                'hma_pct': float(hma_pct),
+                'maj_pct': float(maj_pct),
                 'lar_total': target_lar_total
         })
     else:
@@ -106,12 +106,12 @@ def assemble_stats(lma_sum, mma_sum, hma_sum, peer_lma_sum, peer_mma_sum, peer_h
             THREE_PLACES, rounding=ROUND_HALF_UP)
         stats.update({
                 'peer_lma': peer_lma_sum, 
-                'peer_lma_pct': peer_lma_pct, 
+                'peer_lma_pct': float(peer_lma_pct),
                 'peer_mma': peer_mma_sum,
-                'peer_mma_pct': peer_mma_pct,
+                'peer_mma_pct': float(peer_mma_pct),
                 'peer_hma': peer_hma_sum,
-                'peer_hma_pct': peer_hma_pct,
-                'peer_maj_pct': peer_maj_pct,
+                'peer_hma_pct': float(peer_hma_pct),
+                'peer_maj_pct': float(peer_maj_pct),
                 'peer_lar_total': peer_lar_total
         })
     else:
@@ -129,13 +129,13 @@ def assemble_stats(lma_sum, mma_sum, hma_sum, peer_lma_sum, peer_mma_sum, peer_h
     odds_hma = odds_ratio(hma_pct, peer_hma_pct)
     odds_maj = odds_ratio(mma_pct+hma_pct, peer_mma_pct+peer_hma_pct)
     stats.update({
-        'odds_lma':odds_lma,
-        'odds_mma':odds_mma,
-        'odds_hma':odds_hma,
-        'odds_maj':odds_maj
+        'odds_lma': odds_lma,
+        'odds_mma': odds_mma,
+        'odds_hma': odds_hma,
+        'odds_maj': odds_maj,
     })
     return stats
-    
+
 
 def odds_ratio(target_pct, peer_pct):
     """
@@ -157,7 +157,7 @@ def odds_ratio(target_pct, peer_pct):
             /
             (Decimal(peer_pct) / Decimal(1 - peer_pct))
         )
-    return odds_ratio.quantize(THREE_PLACES, rounding=ROUND_HALF_UP)
+    return float(odds_ratio.quantize(THREE_PLACES, rounding=ROUND_HALF_UP))
 
 def minority_aggregation_as_json(request):
     """

--- a/hmda/tests/test_views.py
+++ b/hmda/tests/test_views.py
@@ -103,7 +103,7 @@ class ViewsTest(TestCase):
         metro = Geo.objects.filter(geoid="201310000").first()
         peer_list = institution.get_peer_list(metro, False, False)
         self.assertEqual(len(peer_list), 1)
-        self.assertEqual(peer_list[0].institution_id, "201311000000001")
+        self.assertEqual(peer_list[0].pk, "201311000000001")
         
         """Case: Institution has peers in selected metro"""
         institution = Institution.objects.filter(
@@ -114,9 +114,9 @@ class ViewsTest(TestCase):
         peer_list_exclude = institution.get_peer_list(metro, True, False)
         self.assertEqual(len(peer_list_exclude), 2)
         peer_list_order = institution.get_peer_list(metro, False, True)
-        self.assertEqual(peer_list_order[0].institution_id, "201391000000001")
+        self.assertEqual(peer_list_order[0].pk, "201391000000001")
         peer_list_order_exclude = institution.get_peer_list(metro, True, True)
-        self.assertEqual(peer_list_order_exclude[0].institution_id, "201391000000002")
+        self.assertEqual(peer_list_order_exclude[0].pk, "201391000000002")
         self.assertEqual(len(peer_list_exclude), 2) 
 
     def test_loan_originations_http_user_errors(self):

--- a/hmda/views.py
+++ b/hmda/views.py
@@ -34,7 +34,7 @@ def loan_originations(request):
         elif peers == 'true' and metro:
             metro_selected = Geo.objects.filter(geo_type=Geo.METRO_TYPE, geoid=metro).first()
             peer_list = institution_selected.get_peer_list(metro_selected, True, False)
-            if len(peer_list) > 0:
+            if peer_list.exists():
                 query = query.filter(institution__in=peer_list)
             else:
                 query = query.filter(institution=institution_selected)

--- a/mapping/views.py
+++ b/mapping/views.py
@@ -56,7 +56,7 @@ def make_download_url(lender, metro):
         if type(lender) is QuerySet:
             for item in lender:
                 query = '(agency_code=%s AND respondent_id="%s" AND year=%s)'
-                where += query % (item.institution.agency_id, item.institution.respondent_id, item.institution.year)
+                where += query % (item.agency_id, item.respondent_id, item.year)
                 count += 1
                 if(count < len(lender)):
                     where += "OR"

--- a/respondents/models.py
+++ b/respondents/models.py
@@ -138,17 +138,19 @@ class Institution(models.Model):
             half_raw = Decimal(loan_stats.lar_count) / 2
             percent_50 = half_raw.quantize(1, rounding=ROUND_HALF_UP)
             percent_200 = loan_stats.lar_count * 2.0
-            peer_list = LendingStats.objects.filter(
+            peer_stats = LendingStats.objects.filter(
                 geo_id=metro.geoid,
                 fha_bucket=loan_stats.fha_bucket,
                 lar_count__range=(percent_50, percent_200)
             ).select_related('institution')
             if exclude:
-                peer_list = peer_list.exclude(institution=self)
+                peer_stats = peer_stats.exclude(institution=self)
+            peer_list = type(self).objects.filter(
+                pk__in=peer_stats.values_list('institution_id', flat=True))
             if order_by:
-                peer_list = peer_list.order_by('-institution__assets')
+                peer_list = peer_list.order_by('-assets')
             return peer_list
-        return []
+        return type(self).objects.none()
 
     def __unicode__(self):
         return self.name


### PR DESCRIPTION
The API was throwing an exception when generating summary tables due to an incorrect peer institution query and an error serializing `Decimal` objects.