### PR TITLE
Add nginx reverse proxy.

### DIFF
--- a/.docker/nginx.conf.tpl
+++ b/.docker/nginx.conf.tpl
@@ -1,0 +1,41 @@
+worker_processes 1;
+
+events {
+  worker_connections 1024; # increase if you have lots of clients
+  accept_mutex off; # set to 'on' if nginx worker_processes > 1
+}
+
+http {
+  include mime.types;
+  # fallback in case we can't determine a type
+  default_type application/octet-stream;
+  sendfile on;
+
+  upstream app_server {
+    # fail_timeout=0 means we always retry an upstream even if it failed
+    # to return a good HTTP response
+    server app:8000 fail_timeout=0;
+  }
+
+  server {
+    # if no Host match, close the connection to prevent host spoofing
+    listen 8000 default_server;
+    return 444;
+  }
+
+  server {
+    server_name NGINX_HOST;
+    listen 8000 deferred;
+    client_max_body_size 4G;
+    keepalive_timeout 5;
+    location / {
+      proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+      proxy_set_header X-Forwarded-Proto $scheme;
+      proxy_set_header Host $http_host;
+      # we don't want nginx trying to do something clever with
+      # redirects, we set the Host: header above already.
+      proxy_redirect off;
+      proxy_pass http://app_server;
+    }
+  }
+}

--- a/.docker/start_proxy.sh
+++ b/.docker/start_proxy.sh
@@ -1,0 +1,5 @@
+#!/bin/sh
+set -euo pipefail
+
+sed "s/NGINX_HOST/${NGINX_HOST}/g" /etc/nginx/nginx.conf.tpl > /etc/nginx/nginx.conf
+nginx -g 'daemon off;'

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -22,7 +22,18 @@ services:
       PYTHONUNBUFFERED: "1"
       USING_SSL: "False"
     command: .docker/wait_for_db_then pipenv run .docker/start_server.sh
+  proxy:
+    image: nginx:1.13-alpine
+    volumes:
+    - .docker/nginx.conf.tpl:/etc/nginx/nginx.conf.tpl:ro
+    - .docker/start_proxy.sh:/usr/sbin/start_proxy.sh
     ports:
     - 8000:8000
+    depends_on:
+    - app
+    environment:
+      NGINX_HOST: ${NGINX_HOST:-localhost}
+    command: start_proxy.sh
+
 volumes:
   data:


### PR DESCRIPTION
Gunicorn doesn't handle slow or malicious connections, recommending nginx for
reverse proxy. We do just that here in our docker-compose file.