### PR TITLE
Allow CONTACT_US_EMAIL to be set by env.

### DIFF
--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -14,6 +14,7 @@ services:
     - database
     environment:
       ALLOWED_HOSTS: ${ALLOWED_HOSTS:-["localhost", "0.0.0.0", "127.0.0.1"]}
+      CONTACT_US_EMAIL: ${CONTACT_US_EMAIL:-example@example.com}
       DATABASE_URL: postgis://postgres@database/postgres
       DEBUG: ${DEBUG:-true}
       MAPBOX_TOKEN: ${MAPBOX_TOKEN:-pk.eyJ1IjoiY2ZwYiIsImEiOiJodmtiSk5zIn0.VkCynzmVYcLBxbyHzlvaQw}


### PR DESCRIPTION
This allows it to be set at docker-compose startup time.