### PR TITLE
Add support for importing pngs.

### DIFF
--- a/frontend/custom_typings/import-png.d.ts
+++ b/frontend/custom_typings/import-png.d.ts
@@ -1,0 +1,4 @@
+declare module "*.png" {
+  const value: any;
+  export = value;
+}


### PR DESCRIPTION
Typescript doesn't generally allow us to import PNGs in a webpack style.
This fixes that by shimming the png type.